### PR TITLE
Updates to numpy usage and CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         python-version: [3.8, 3.11, 3.12]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.11, 3.12]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/fdm/fdm.py
+++ b/fdm/fdm.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 import sympy as sp
 import numpy as np
@@ -9,7 +10,7 @@ log = logging.getLogger(__name__)
 
 
 def _get_dtype(x):
-    return np.array(x, copy=False).dtype
+    return np.asarray(x).dtype
 
 
 def _ensure_float(x):
@@ -35,13 +36,13 @@ def _compute_coefs_mults(grid, deriv):
     except KeyError:
         # Compute coefficients.
         mat = sp.Matrix([[g ** i for g in grid] for i in range(order)])
-        coefs = mat.inv()[:, deriv] * np.math.factorial(deriv)
+        coefs = mat.inv()[:, deriv] * math.factorial(deriv)
 
         # Compute parts of the FDM.
         coefs = np.array([float(c) for c in coefs])
         df_magnitude_mult = float(
             sum([abs(c * g ** order) for c, g in zip(coefs, grid)])
-            / np.math.factorial(order)
+            / math.factorial(order)
         )
         f_error_mult = float(sum([abs(c) for c in coefs]))
 

--- a/fdm/multivariate.py
+++ b/fdm/multivariate.py
@@ -48,7 +48,7 @@ def gradient(f, method=default_adaptive_method):
 
     def compute_gradient(x):
         # Query the object once to get the data type.
-        dtype = np.array(f(x), copy=False).dtype
+        dtype = np.asarray(f(x)).dtype
 
         # Handle edge case where `x` is a scalar.
         if np.shape(x) == ():
@@ -94,7 +94,7 @@ def jvp(f, v, method=default_adaptive_method):
 
     def compute_jvp(x):
         # Query the object once to get the data type.
-        dtype = np.array(f(x), copy=False).dtype
+        dtype = np.asarray(f(x)).dtype
         zero = np.array(0).astype(dtype)
         return method(lambda eps: f(x + eps * v), zero)
 
@@ -117,7 +117,7 @@ def jacobian(f, method=default_adaptive_method):
         size_in = np.size(x)  # Size of input.
 
         # Query the object once to get the data type and output size.
-        fx = np.array(f(x), copy=False)
+        fx = np.asarray(f(x))
         dtype = fx.dtype
         size_out = fx.size
 


### PR DESCRIPTION
Hi @wesselb - stemming from [this discussion](https://github.com/alan-turing-institute/deepsensor/issues/118) I've had a go at updating the numpy calls in this package to be compatible with version 2 (as well as back-compatible with numpy ~1.26). The tests pass on CI with numpy 2 and passed locally with numpy 1.26.

I also noticed that some of the GitHub actions were on deprecated versions so this PR updates those too as well as running the tests with some more recent versions of python.

If you want to continue to support python 3.6 (probably not necessary) then I can re-add that version (I should also update the version in `setup.py`).

If you'd rather not have those changes in this PR, I'm happy to remove them.